### PR TITLE
How could this slip through?

### DIFF
--- a/panel_scrolled/panel_scrolled.h
+++ b/panel_scrolled/panel_scrolled.h
@@ -77,7 +77,7 @@ public:
         });
 
         // arrange visible panel with scrolls at right and bottom
-        myPlace.div("<vert <<panel><scroll_vert weight=16>> <scroll_horiz weight=16>>>");
+        myPlace.div("<vert <<panel><scroll_vert weight=16>> <scroll_horiz weight=16>>");
         myPlace["panel"] << myVisible;
         myPlace["scroll_vert"] << myScrollVert;
         myPlace["scroll_horiz"] << myScrollHoriz;


### PR DESCRIPTION
Extraneous '>' removed in layout.